### PR TITLE
$grid-gutter-width is deprecated

### DIFF
--- a/src/sass/understrap/understrap/understrap.scss
+++ b/src/sass/understrap/understrap/understrap.scss
@@ -1,6 +1,6 @@
 // Some basic padding for all wrappers
 .wrapper {
-  padding:$grid-gutter-width 0;
+  padding:$grid-gutter-width-base 0;
 }
 
 // Reset hero wrapper padding to 0


### PR DESCRIPTION
The following SCSS variable has been deprecated in Bootstrap 4 Alpha 5.
It's already redefined in the parent theme, but not there.
