### PR TITLE
SCSS errors are shown using gulp-notify.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -39,6 +39,11 @@ var browserSync = require('browser-sync').create();
 var del = require('del');
 var cleanCSS = require('gulp-clean-css');
 var gulpSequence = require('gulp-sequence')
+var notify = require('gulp-notify');
+var gulpif = require('gulp-if');
+
+// Whether to gulp-notify scss errors
+var notifySassErrors = true;
 
 function swallowError(self, error) {
     console.log(error.toString())
@@ -98,7 +103,9 @@ gulp.task('sass', function () {
                 this.emit('end');
             }
         }))
-        .pipe(sass())
+        .pipe(gulpif(notifySassErrors, sass().on('error', function (error) {
+            return notify().write(error)
+        }), sass()))
         .pipe(gulp.dest('./css'))
         .pipe(rename('custom-editor-style.css'))
     return stream;

--- a/package.json
+++ b/package.json
@@ -10,14 +10,13 @@
     "type": "git",
     "url": "https://github.com/holger1411/understrap-child.git"
   },
-    "keywords": [
+  "keywords": [
     "wordpress",
     "theme",
     "framework",
     "bootstrap",
     "underscores"
   ],
-
   "author": "Holger Koenemann",
   "license": "GPL-2.0",
   "bugs": {
@@ -49,8 +48,11 @@
     "merge2": "^1.1.0",
     "popper.js": "^1.11.1",
     "run-sequence": "^2.0.0",
-    "undescores-for-npm": "^1.0.0",
-    "understrap": "^0.6.5"
+    "understrap": "^0.6.5",
+    "undescores-for-npm": "^1.0.0"
+  },
+  "devDependencies": {
+    "gulp-if": "^2.0.2",
+    "gulp-notify": "^3.0.0"
   }
-    
 }

--- a/package.json
+++ b/package.json
@@ -33,9 +33,11 @@
     "gulp-clone": "^1.0.0",
     "gulp-concat": "^2.6.1",
     "gulp-cssnano": "^2.1.2",
+    "gulp-if": "^2.0.2",
     "gulp-ignore": "^2.0.2",
     "gulp-imagemin": "^3.3.0",
     "gulp-merge": "^0.1.1",
+    "gulp-notify": "^3.0.0",
     "gulp-plumber": "^1.1.0",
     "gulp-rename": "^1.2.2",
     "gulp-rimraf": "^0.2.1",
@@ -51,8 +53,5 @@
     "understrap": "^0.6.5",
     "undescores-for-npm": "^1.0.0"
   },
-  "devDependencies": {
-    "gulp-if": "^2.0.2",
-    "gulp-notify": "^3.0.0"
-  }
+  "devDependencies": {}
 }


### PR DESCRIPTION
Errors are shown by default, but can be turned off changing a variable.