### PR TITLE
Fix for 'imagemin-watch' not in gulpfile

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -98,7 +98,7 @@ gulp.task( 'watch', function() {
     gulp.watch( [paths.dev + '/js/**/*.js', 'js/**/*.js', '!js/child-theme.js', '!js/child-theme.min.js'], ['scripts'] );
 
     //Inside the watch task.
-    gulp.watch( paths.imgsrc + '/**', ['imagemin-watch'] );
+    gulp.watch( paths.imgsrc + '/**', ['imagemin'] );
 });
 
 // Run:


### PR DESCRIPTION
Task is named: `imagemin` but gulp.watch is looking for `imagemin-watch`. Remove `-watch`