### PR TITLE
Adds versioning to scripts enqueued and move scripts into separate file

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -1,25 +1,3 @@
 <?php
-function understrap_remove_scripts() {
-    wp_dequeue_style( 'understrap-styles' );
-    wp_deregister_style( 'understrap-styles' );
 
-    wp_dequeue_script( 'understrap-scripts' );
-    wp_deregister_script( 'understrap-scripts' );
-
-    // Removes the parent themes stylesheet and scripts from inc/enqueue.php
-}
-add_action( 'wp_enqueue_scripts', 'understrap_remove_scripts', 20 );
-
-add_action( 'wp_enqueue_scripts', 'theme_enqueue_styles' );
-function theme_enqueue_styles() {
-
-	// Get the theme data
-	$the_theme = wp_get_theme();
-    wp_enqueue_style( 'child-understrap-styles', get_stylesheet_directory_uri() . '/css/child-theme.min.css', array(), $the_theme->get( 'Version' ) );
-    wp_enqueue_script( 'jquery');
-	wp_enqueue_script( 'popper-scripts', get_template_directory_uri() . '/js/popper.min.js', array(), false);
-    wp_enqueue_script( 'child-understrap-scripts', get_stylesheet_directory_uri() . '/js/child-theme.min.js', array(), $the_theme->get( 'Version' ), true );
-    if ( is_singular() && comments_open() && get_option( 'thread_comments' ) ) {
-        wp_enqueue_script( 'comment-reply' );
-    }
-}
+get_template_part('functions/scripts');

--- a/functions/scripts.php
+++ b/functions/scripts.php
@@ -1,0 +1,25 @@
+<?php
+function understrap_remove_scripts() {
+    wp_dequeue_style( 'understrap-styles' );
+    wp_deregister_style( 'understrap-styles' );
+
+    wp_dequeue_script( 'understrap-scripts' );
+    wp_deregister_script( 'understrap-scripts' );
+
+    // Removes the parent themes stylesheet and scripts from inc/enqueue.php
+}
+add_action( 'wp_enqueue_scripts', 'understrap_remove_scripts', 20 );
+
+add_action( 'wp_enqueue_scripts', 'theme_enqueue_styles' );
+function theme_enqueue_styles() {
+
+	// Get the theme data
+	$the_theme = wp_get_theme();
+    wp_enqueue_style( 'child-understrap-styles', get_stylesheet_directory_uri() . '/css/child-theme.min.css', array(), $the_theme->get( 'Version' ) );
+    wp_enqueue_script( 'jquery');
+	wp_enqueue_script( 'popper-scripts', get_template_directory_uri() . '/js/popper.min.js', array(), false);
+    wp_enqueue_script( 'child-understrap-scripts', get_stylesheet_directory_uri() . '/js/child-theme.min.js', array(), $the_theme->get( 'Version' ), true );
+    if ( is_singular() && comments_open() && get_option( 'thread_comments' ) ) {
+        wp_enqueue_script( 'comment-reply' );
+    }
+}

--- a/functions/scripts.php
+++ b/functions/scripts.php
@@ -2,37 +2,37 @@
 
 // set debug version
 if (true == WP_DEBUG) {
-    $date = new DateTime();
-    $ver_num = $date->getTimestamp();
+	$date = new DateTime();
+	$ver_num = $date->getTimestamp();
 } else {
-    $ver_num = wp_get_theme()->get( 'Version' );
+	$ver_num = wp_get_theme()->get( 'Version' );
 }
 
 
 function understrap_remove_scripts() {
-    wp_dequeue_style( 'understrap-styles' );
-    wp_deregister_style( 'understrap-styles' );
+	wp_dequeue_style( 'understrap-styles' );
+	wp_deregister_style( 'understrap-styles' );
 
-    wp_dequeue_script( 'understrap-scripts' );
-    wp_deregister_script( 'understrap-scripts' );
+	wp_dequeue_script( 'understrap-scripts' );
+	wp_deregister_script( 'understrap-scripts' );
 
-    // Removes the parent themes stylesheet and scripts from inc/enqueue.php
+	// Removes the parent themes stylesheet and scripts from inc/enqueue.php
 }
 
 add_action( 'wp_enqueue_scripts', 'understrap_remove_scripts', 20 );
 
 function theme_enqueue_styles() {
 
-    // if debug load non-min css
-    if (true == WP_DEBUG) {
-        wp_enqueue_style( 'child-understrap-styles', get_stylesheet_directory_uri() . '/css/child-theme.css', array(), $ver_num);
-        wp_enqueue_script( 'child-scripts', get_stylesheet_directory_uri() . '/js/child-theme.js', array(), $ver_num, true );
-    } else {
-        wp_enqueue_style( 'child-understrap-styles', get_stylesheet_directory_uri() . '/css/child-theme.min.css', array(), $ver_num);
-        wp_enqueue_script( 'child-scripts', get_stylesheet_directory_uri() . '/js/child-theme.min.js', array(), $ver_num, true );
-    }
+	// if debug load non-min css
+	if (true == WP_DEBUG) {
+		wp_enqueue_style( 'child-understrap-styles', get_stylesheet_directory_uri() . '/css/child-theme.css', array(), $ver_num);
+		wp_enqueue_script( 'child-scripts', get_stylesheet_directory_uri() . '/js/child-theme.js', array(), $ver_num, true );
+	} else {
+		wp_enqueue_style( 'child-understrap-styles', get_stylesheet_directory_uri() . '/css/child-theme.min.css', array(), $ver_num);
+		wp_enqueue_script( 'child-scripts', get_stylesheet_directory_uri() . '/js/child-theme.min.js', array(), $ver_num, true );
+	}
 
-    wp_enqueue_script( 'child-scripts', get_stylesheet_directory_uri() . '/js/theme.js', array(), $ver_num, true );
+	wp_enqueue_script( 'child-scripts', get_stylesheet_directory_uri() . '/js/theme.js', array(), $ver_num, true );
 
 
 }

--- a/functions/scripts.php
+++ b/functions/scripts.php
@@ -3,10 +3,11 @@
 // set debug version
 if (true == WP_DEBUG) {
 	$date = new DateTime();
-	$ver_num = $date->getTimestamp();
+	define('THEME_VERSION_NUM', $date->getTimestamp() );
 } else {
-	$ver_num = wp_get_theme()->get( 'Version' );
+	define('THEME_VERSION_NUM', wp_get_theme()->get( 'Version' ));
 }
+
 
 
 function understrap_remove_scripts() {

--- a/functions/scripts.php
+++ b/functions/scripts.php
@@ -1,4 +1,14 @@
 <?php
+
+// set debug version
+if (true == WP_DEBUG) {
+    $date = new DateTime();
+    $ver_num = $date->getTimestamp();
+} else {
+    $ver_num = wp_get_theme()->get( 'Version' );
+}
+
+
 function understrap_remove_scripts() {
     wp_dequeue_style( 'understrap-styles' );
     wp_deregister_style( 'understrap-styles' );
@@ -8,18 +18,23 @@ function understrap_remove_scripts() {
 
     // Removes the parent themes stylesheet and scripts from inc/enqueue.php
 }
+
 add_action( 'wp_enqueue_scripts', 'understrap_remove_scripts', 20 );
 
-add_action( 'wp_enqueue_scripts', 'theme_enqueue_styles' );
 function theme_enqueue_styles() {
 
-	// Get the theme data
-	$the_theme = wp_get_theme();
-    wp_enqueue_style( 'child-understrap-styles', get_stylesheet_directory_uri() . '/css/child-theme.min.css', array(), $the_theme->get( 'Version' ) );
-    wp_enqueue_script( 'jquery');
-	wp_enqueue_script( 'popper-scripts', get_template_directory_uri() . '/js/popper.min.js', array(), false);
-    wp_enqueue_script( 'child-understrap-scripts', get_stylesheet_directory_uri() . '/js/child-theme.min.js', array(), $the_theme->get( 'Version' ), true );
-    if ( is_singular() && comments_open() && get_option( 'thread_comments' ) ) {
-        wp_enqueue_script( 'comment-reply' );
+    // if debug load non-min css
+    if (true == WP_DEBUG) {
+        wp_enqueue_style( 'child-understrap-styles', get_stylesheet_directory_uri() . '/css/child-theme.css', array(), $ver_num);
+        wp_enqueue_script( 'child-scripts', get_stylesheet_directory_uri() . '/js/child-theme.js', array(), $ver_num, true );
+    } else {
+        wp_enqueue_style( 'child-understrap-styles', get_stylesheet_directory_uri() . '/css/child-theme.min.css', array(), $ver_num);
+        wp_enqueue_script( 'child-scripts', get_stylesheet_directory_uri() . '/js/child-theme.min.js', array(), $ver_num, true );
     }
+
+    wp_enqueue_script( 'child-scripts', get_stylesheet_directory_uri() . '/js/theme.js', array(), $ver_num, true );
+
+
 }
+
+add_action( 'wp_enqueue_scripts', 'theme_enqueue_styles' );


### PR DESCRIPTION
Problem: WP caches the css/js with whatever version the theme is. This stops you from seeing changes made in development.

Solution: I check if wp_debug is enabled to check whether the theme is in development. If in development then I set version number appended to the assets as a unique unix datetime. This makes sure the files are not cached in development. If it is in production it uses the version number set in the themes style.css

I also moved the scripts into it's own file in a new folder (functions) and I also cleaned the file to just use tabs (instead of a mix of tabs/space)