### PR TITLE
Add loading for translation files in Child-Theme

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -23,3 +23,8 @@ function theme_enqueue_styles() {
         wp_enqueue_script( 'comment-reply' );
     }
 }
+
+function add_child_theme_textdomain() {
+    load_child_theme_textdomain( 'understrap-child', get_stylesheet_directory() . '/languages' );
+}
+add_action( 'after_setup_theme', 'add_child_theme_textdomain' );


### PR DESCRIPTION
Add loading for translation files in Child-Theme for text-domain 'understrap-child'. Didn´t work before.