### PR TITLE
Fix broken minifycss task in gulpfile.js

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -87,7 +87,7 @@ gulp.task( 'cssnano', function() {
 });
 
 gulp.task( 'minifycss', function() {
-  return gulp.src( `${paths.css}/child-theme.css}`, { allowEmpty: true } )
+  return gulp.src( `${paths.css}/child-theme.css`, { allowEmpty: true } )
   .pipe( sourcemaps.init( { loadMaps: true } ) )
     .pipe( cleanCSS( { compatibility: '*' } ) )
     .pipe( plumber( {


### PR DESCRIPTION
On line 90 an extra } was added onto the name of the CSS file which broke the minifycss task.