### PR TITLE
Fix mispelled path and package name

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -181,11 +181,11 @@ gulp.task( 'copy-assets', function() {
 
 
 // _s SCSS files
-    gulp.src( `${paths.node}undescores-for-npm/sass/media/*.scss` )
+    gulp.src( `${paths.node}underscores-for-npm/sass/media/*.scss` )
         .pipe( gulp.dest( `${paths.dev}/sass/underscores` ) );
 
 // _s JS files into /src/js
-    gulp.src( `${paths.node}undescores-for-npm/js/skip-link-focus-fix.js` )
+    gulp.src( `${paths.node}underscores-for-npm/js/skip-link-focus-fix.js` )
         .pipe( gulp.dest( `${paths.dev}/js` ) );
 
 // Copy Popper JS files

--- a/package.json
+++ b/package.json
@@ -50,6 +50,6 @@
     "popper.js": "^1.15.0",
     "run-sequence": "^2.2.1",
     "understrap": "^0.9.1",
-    "undescores-for-npm": "^1.0.0"
+    "underscores-for-npm": "^1.0.0"
   }
 }


### PR DESCRIPTION
Fix for issue #251 

There was a misspelled path that was causing gulp not to find the assets it was referencing.