### PR TITLE
fixes inf loop for js watcher

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -139,8 +139,8 @@ gulp.task( 'watch', function() {
 		[
 			paths.dev + '/js/**/*.js',
 			'js/**/*.js',
-			'!js/theme.js',
-			'!js/theme.min.js',
+			'!js/child-theme.js',
+			'!js/child-theme.min.js',
 		],
 		gulp.series( 'scripts' )
 	);


### PR DESCRIPTION
Running `gulp watch` causes `scripts` to run in an infinite loop because the watcher is ignoring `/js/theme.js` but not `/js/child-theme.js`, which is what the child theme generates.