### PR TITLE
Fix for cache-busting error in #376

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -38,12 +38,12 @@ function theme_enqueue_styles() {
 	$theme_styles  = "/css/child-theme{$suffix}.css";
 	$theme_scripts = "/js/child-theme{$suffix}.js";
 	
-	$css_version = $theme_version . '.' . filemtime( get_stylesheet_directory_uri() . $theme_styles );
+	$css_version = $theme_version . '.' . filemtime( get_stylesheet_directory() . $theme_styles );
 
 	wp_enqueue_style( 'child-understrap-styles', get_stylesheet_directory_uri() . $theme_styles, array(), $css_version );
 	wp_enqueue_script( 'jquery' );
 	
-	$js_version = $theme_version . '.' . filemtime( get_stylesheet_directory_uri() . $theme_scripts );
+	$js_version = $theme_version . '.' . filemtime( get_stylesheet_directory() . $theme_scripts );
 	
 	wp_enqueue_script( 'child-understrap-scripts', get_stylesheet_directory_uri() . $theme_scripts, array(), $js_version, true );
 	if ( is_singular() && comments_open() && get_option( 'thread_comments' ) ) {


### PR DESCRIPTION
The `filemtime` function fails in some circumstances and needs a path to the files rather than the URL. 