### PR TITLE
Remove .git folder from dist

### DIFF
--- a/src/build/dist-build.js
+++ b/src/build/dist-build.js
@@ -9,6 +9,7 @@ async function copyDir(src, dest) {
 		'dist',
 		'src',
 		'.github',
+		'.git',
 		'.browserslistrc',
 		'.editorconfig',
 		'.gitattributes',


### PR DESCRIPTION
It would probably be better to take the dist-build script from Understrap and increase the required node version to `>=16`.

See https://github.com/understrap/understrap/issues/2094